### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,8 @@
 name: Deploy AdonisJS App
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]  # 当 main 分支收到推送时触发


### PR DESCRIPTION
Potential fix for [https://github.com/pdnode-team/account-backend/security/code-scanning/2](https://github.com/pdnode-team/account-backend/security/code-scanning/2)

In general, the fix is to explicitly declare a restrictive `permissions:` block, either at the workflow root (applies to all jobs) or per job, granting only what is required. This deploy workflow only needs to read repository contents for checkout; it does not need to write to the repository, manage issues, or modify pull requests. Therefore we can safely set `permissions: contents: read` as the minimal least-privilege configuration.

The best change here, without altering functionality, is to add a `permissions:` block at the workflow root, just under `name: Deploy AdonisJS App`. This will apply to the `deploy` job since it does not define its own `permissions`. The change is confined to `.github/workflows/deploy.yml`. No additional imports or methods are needed because this is pure YAML configuration for GitHub Actions.

Concretely:
- Edit `.github/workflows/deploy.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

after line 1 (`name: Deploy AdonisJS App`) and before the `on:` block. No other lines need to be changed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance security protocols.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->